### PR TITLE
Configure for single motor

### DIFF
--- a/fdcan_h730_v3.0.4/Core/Src/main.c
+++ b/fdcan_h730_v3.0.4/Core/Src/main.c
@@ -121,7 +121,7 @@ int main(void)
         {
             tick_100ms = HAL_GetTick();
 
-            test_motor_control(2);
+            test_motor_control(1);
             // test_motor_many();
 
         }

--- a/fdcan_h730_v3.0.4/src/motor/motor.c
+++ b/fdcan_h730_v3.0.4/src/motor/motor.c
@@ -4,26 +4,12 @@
 
 /************************************下面为需要修改的部分*******************************************/
 
-static motor_state_s motor_state_port[MOTOR_PORT_NUM][MOTOR_MAX_NUM] =  // 下标 + 1 = 电机 ID 
+static motor_state_s motor_state_port[MOTOR_PORT_NUM][MOTOR_MAX_NUM] =  // 下标 + 1 = 电机 ID
 {
     {  // CAN 通道 PORT1
         {  // ID = 1
-            .model = M4438_30,
-        },
-
-        {  // ID = 2
             .model = M5047_36,
-        }
-    },
-
-    {  // CAN 通道 PORT2
-        {  // ID = 1
-            .model = M4438_30,
         },
-
-        {  // ID = 2
-            .model = M5047_36,
-        }
     },
 };
 
@@ -34,12 +20,6 @@ const port_mapping_s port_maping[MOTOR_PORT_NUM] =  // 通道映射表
         .port = PORT1,
         .fdcan = &hfdcan2,
         .state = motor_state_port[0],
-    },
-
-    {
-        .port = PORT2,
-        .fdcan = &hfdcan3,
-        .state = motor_state_port[1],
     },
 };
 

--- a/fdcan_h730_v3.0.4/src/motor/motor.h
+++ b/fdcan_h730_v3.0.4/src/motor/motor.h
@@ -4,8 +4,8 @@
 
 
 
-#define  MOTOR_PORT_NUM  2  // 使用 CAN 通道数量  
-#define  MOTOR_MAX_NUM   2  // 单个 CAN 通道所连接的最大电机数量
+#define  MOTOR_PORT_NUM  1  // 使用 CAN 通道数量
+#define  MOTOR_MAX_NUM   1  // 单个 CAN 通道所连接的最大电机数量
 
 
 


### PR DESCRIPTION
## Summary
- configure FDCAN example for a single motor
- update port mapping to use only FDCAN2
- call `test_motor_control(1)` from `main.c`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6880909626748329953cbc234ca2839b